### PR TITLE
Pass User-Agent header to AoC request

### DIFF
--- a/AoCTiles/create_aoc_tiles.py
+++ b/AoCTiles/create_aoc_tiles.py
@@ -198,7 +198,7 @@ def request_leaderboard(year: int) -> dict[int, DayScores]:
             return leaderboard
     with open(SESSION_COOKIE_PATH) as cookie_file:
         session_cookie = cookie_file.read().strip()
-        data = requests.get(PERSONAL_LEADERBOARD_URL.format(year=year), cookies={"session": session_cookie}).text
+        data = requests.get(PERSONAL_LEADERBOARD_URL.format(year=year), headers={"User-Agent": "https://github.com/LiquidFun/adventofcode by Brutenis Gliwa"}, cookies={"session": session_cookie}).text
         leaderboard_path.parent.mkdir(exist_ok=True, parents=True)
         with open(leaderboard_path, "w") as file:
             file.write(data)


### PR DESCRIPTION
Hey! Thank you so much for the script, it’s really nice. I [read today](https://www.reddit.com/r/adventofcode/comments/z9dhtd/please_include_your_contact_info_in_the_useragent/) that the creator of AoC asks people to pass their information in the `User-Agent` header so they don’t get excluded/rate-limited. This PR does just that. :) 